### PR TITLE
Fixed: prevent reconnection attempt if there was a connection error

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -45,6 +45,9 @@
       socket = io.connect(url, {
         path: pathToSocketIO
       });
+      socket.on('connect_error', function() {
+        return socket.io.reconnection(false);
+      });
       ref = this.events;
       results = [];
       for (j = 0, len = ref.length; j < len; j++) {

--- a/src/client.coffee
+++ b/src/client.coffee
@@ -28,6 +28,10 @@ class CozySocketListener
         pathToSocketIO = "/#{window.location.pathname.substring(1)}socket.io"
         socket = io.connect url, path: pathToSocketIO
 
+        # prevent reconnection attempt if there was a connection error
+        socket.on 'connect_error', ->
+            socket.io.reconnection false
+
         for event in @events
             socket.on event, @callbackFactory(event)
 


### PR DESCRIPTION
Following the issue we noticed when the connection is lost, socket.io becomes crazy and spams connection attempts.

I made a fix based on https://github.com/Automattic/socket.io-client/issues/737#issuecomment-61381603.

This PR is not built.