### PR TITLE
Make it lighter

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,3 +1,8 @@
+Cakefile
+coffeelint.json
+src
+tests
+
 lib-cov
 *.seed
 *.log

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ americano.start(options, function(app, server){
 
     // notification events should be proxyed to client
     realtime = RealtimeAdapter(app, ['notification.*']);
-    
+
     // custom callback for alarm events
     realtime.on('alarm.*', function(event, msg){
         // event = 'alarm.update' or 'alarm.create' or 'alarm.delete'
@@ -58,9 +58,9 @@ For more complex usages, refer to the code of cozy applications
 
 ## What is Cozy?
 
-![Cozy Logo](https://raw.github.com/mycozycloud/cozy-setup/gh-pages/assets/images/happycloud.png)
+![Cozy Logo](https://raw.github.com/cozy/cozy-setup/gh-pages/assets/images/happycloud.png)
 
-[Cozy](http://cozy.io) is a platform that brings all your web services in the
+[Cozy](https://cozy.io) is a platform that brings all your web services in the
 same private space.  With it, your web apps and your devices can share data
 easily, providing you
 with a new experience. You can install Cozy on your own hardware where no one
@@ -72,6 +72,6 @@ own one too.
 You can reach the Cozy community via various support:
 
 * IRC #cozycloud on irc.freenode.net
-* Post on our [Forum](https://groups.google.com/forum/?fromgroups#!forum/cozy-cloud)
-* Post issues on the [Github repos](https://github.com/mycozycloud/)
-* Via [Twitter](http://twitter.com/mycozycloud)
+* Post on our [Forum](https://forum.cozy.io)
+* Post issues on the [Github repos](https://github.com/cozy/)
+* Via [Twitter](https://twitter.com/mycozycloud)

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/mycozycloud/cozy-realtime-adapter"
+    "url": "https://github.com/cozy/cozy-realtime-adapter"
   },
   "author": {
     "name": "Romain"
@@ -20,14 +20,6 @@
     "printit": "0.1.6",
     "socket.io": "1.3.4"
   },
-  "readme": "# Socket Listener\r\n\r\nHelper library for interaction with cozy-data-system data changes notifications\r\n\r\n##Server-Side\r\n- transform Redis events to Socket.io\r\n\r\n##Client-Side\r\n- transform socket.io events to Backbone manipulation\r\n\r\n# About Cozy\r\n\r\nCozy Notes is suited to be deployed on the Cozy platform. Cozy is the personal\r\nserver for everyone. It allows you to install your every day web applications\r\neasily on your server, a single place you control. This means you can manage\r\nefficiently your data while protecting your privacy without technical skills.\r\n\r\nMore informations and hosting services on:\r\nhttps://cozycloud.cc\r\n\r\n# Cozy on IRC\r\n\r\nFeel free to check out our IRC channel (#cozycloud on irc.freenode.org) if you have any technical issues/inquiries or simply to speak about Cozy cloud in general.\r\n",
-  "readmeFilename": "README.md",
-  "_id": "cozy-realtime-adapter@0.0.7",
-  "dist": {
-    "shasum": "cb16e6fb52e1dfb2b40f5aeb2bf324938ec56d9c"
-  },
-  "_from": "cozy-realtime-adapter@= 0.0.7",
-  "_resolved": "https://registry.npmjs.org/cozy-realtime-adapter/-/cozy-realtime-adapter-0.0.7.tgz",
   "devDependencies": {
     "express": "3.2.5",
     "request-json": "0.5.2"

--- a/package.json
+++ b/package.json
@@ -17,11 +17,11 @@
   "license": "BSD",
   "dependencies": {
     "axon": "0.6.1",
-    "printit": "0.1.6",
-    "socket.io": "1.3.4"
+    "printit": "0.1.15",
+    "socket.io": "1.4.5"
   },
   "devDependencies": {
     "express": "3.2.5",
-    "request-json": "0.5.2"
+    "request-json": "0.5.5"
   }
 }


### PR DESCRIPTION
This library is used by a lot of our apps and if we can gain some MB, it's always that less to download when installing our apps. Mainly, moving from socket.io 1.3.4 to 1.4.5, we reduce the size by 1.7MB.
